### PR TITLE
Force node separation on comma while compressing.

### DIFF
--- a/libs/lz-string.js
+++ b/libs/lz-string.js
@@ -87,8 +87,13 @@ var LZString = (function () {
 
         for (j = 1; j < uncompressed.length; j++) {
           c = uncompressed.charCodeAt(j);
-          // does the new charCode match an existing prefix?
-          nextNode = node.d[c];
+          // separate on comma leading to get gain while processing JSON!
+          if (c===44) {
+            nextNode=false;
+          } else {
+            // does the new charCode match an existing prefix?
+            nextNode = node.d[c];
+          }
           if (nextNode) {
             // continue with next prefix
             node = nextNode;


### PR DESCRIPTION
Compression of JSON is more efficient when nodes are split on comma. No any change to format. Due to efficient compression about 10% better compression, 20% faster compression and decompression. It seams to be beneficial for other payloads too.